### PR TITLE
Fix btnApps trigger center alignment

### DIFF
--- a/src/components/btnApps.vue
+++ b/src/components/btnApps.vue
@@ -74,7 +74,7 @@ export default {
     background var(--fondo2)
     color var(--text-color)
     display flex
-    align-content center
+    align-items center
     justify-content center
 
     i


### PR DESCRIPTION
This fixes a small flex issue with the btnApps trigger.
Although the material icons' `left-chevron` icon is slightly still misaligned (a bit too much spacing on the right).

The GIFs illustrate the small fix:
![broken](https://user-images.githubusercontent.com/9140811/47283525-72cf8180-d5ec-11e8-80b2-d682c4a1c10f.gif)

![fixed](https://user-images.githubusercontent.com/9140811/47283537-782ccc00-d5ec-11e8-8e8b-2f3ed8124ac6.gif)
